### PR TITLE
Handle new filter names, address master flat bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
Changes filter name handling to account for new filter names (e.g., "SDSS r #1") by cleaning the filter names.
Fixes bug caused by flats named only after the filter letter, including (1) numbered filter names (as above) and, (2), two different filters using the same master flat (e.g., SDSS r becomes master_flat_r.fits, but CUVR becomes master_flat_R.fits, which is indistinguishable from master_flat_r.fits on case-insensitive operating systems, e.g., default MacOS).
